### PR TITLE
Enable Continuous Delivery with Travis/Serverless

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: build-notifier
+service: ci-notifier
 
 plugins:
   - serverless-offline


### PR DESCRIPTION
## Proposed Changes

- Change application name in `serverless.yml` to deploy with Travis

## Notes

Will avoid collision with the other notifier app.
