### PR TITLE
Fix Old Name in serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -13,7 +13,7 @@ provider:
     PRIVATE_KEY: ${env:PRIVATE_KEY}
 
 functions:
-  build-notifier:
+  ci-notifier:
     handler: handler.main
     events:
       - http:


### PR DESCRIPTION
## Proposed Changes

- Change function name in `serverless.yml` to `ci-notifier`

## Notes

None.
